### PR TITLE
readme - remove broken link to readthedocs, point to the docs.cern.ch site instead

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,4 +30,4 @@ Invenio module for managing vocabularies, based on Invenio-Records and Invenio-R
 - Helpers for importing vocabularies
 
 Further documentation is available on
-https://invenio-vocabularies.readthedocs.io/
+https://inveniordm.docs.cern.ch/customize/vocabularies/


### PR DESCRIPTION
The readthedocs link is broken, it seems like most documentation has been moved to docs.cern.ch. There's two places for vocabs, one under Customize and one under REST API, but Customize seems more general. Not sure if there is a more generic (not RDM) set of docs out there.